### PR TITLE
fix: Include necessary files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
       "svelte": "./dist/index.js"
     }
   },
+  "files": [
+    "dist",
+    "LICENSE",
+    "package.json",
+    "README.md"
+  ],
   "scripts": {
     "build": "svelte-package",
     "test": "vitest"


### PR DESCRIPTION
- Add 'files' array to package.json to explicitly include 'dist', 'LICENSE', 'package.json', and 'README.md' in the published package.