### PR TITLE
ci: remove unnecessary git_tag option

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -30,6 +30,5 @@ jobs:
         uses: taj54/universal-version-bump@v0.14.0
         with:
           release_type: ${{ inputs.release_type }}
-          git_tag: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Simplified version bump workflow.
- Removed redundant `git_tag` setting.
- Improved workflow efficiency.